### PR TITLE
Guard gallery behavior when container is missing

### DIFF
--- a/script.js
+++ b/script.js
@@ -321,7 +321,11 @@ const GALLERY_CONFIG = {
 // Load gallery photos dynamically
 function loadGalleryPhotos() {
     const galleryScroll = document.getElementById('gallery-scroll');
-    
+
+    if (!galleryScroll) {
+        return;
+    }
+
     // Clear existing content
     galleryScroll.innerHTML = '';
     
@@ -343,9 +347,14 @@ function loadGalleryPhotos() {
 
 // Gallery scrolling function
 function scrollGallery(direction) {
-    const galleryScroll = document.querySelector('.gallery-scroll');
+    const galleryScroll = document.getElementById('gallery-scroll');
+
+    if (!galleryScroll) {
+        return;
+    }
+
     const scrollAmount = 320; // Width of one gallery item + gap
-    
+
     if (direction === 1) {
         galleryScroll.scrollBy({ left: scrollAmount, behavior: 'smooth' });
     } else {
@@ -355,5 +364,11 @@ function scrollGallery(direction) {
 
 // Initialize gallery when page loads
 document.addEventListener('DOMContentLoaded', function() {
+    const galleryScroll = document.getElementById('gallery-scroll');
+
+    if (!galleryScroll) {
+        return;
+    }
+
     loadGalleryPhotos();
 });


### PR DESCRIPTION
## Summary
- add null checks to avoid populating the gallery when its container is absent
- ensure scroll handlers and initialization guard against missing gallery markup

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d980eab070832292e31a1bdf9b7c17