### PR TITLE
Move notification presentation to stylesheet

### DIFF
--- a/script.js
+++ b/script.js
@@ -137,96 +137,36 @@ function showNotification(message, type = 'info') {
             <button class="notification-close">&times;</button>
         </div>
     `;
-    
-    // Add styles
-    notification.style.cssText = `
-        position: fixed;
-        top: 90px;
-        right: 20px;
-        background: ${type === 'success' ? '#4CAF50' : type === 'error' ? '#f44336' : '#2196F3'};
-        color: white;
-        padding: 15px 20px;
-        border-radius: 8px;
-        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-        z-index: 10000;
-        max-width: 400px;
-        animation: slideInRight 0.3s ease;
-    `;
-    
+
+    notification.setAttribute('role', type === 'error' ? 'alert' : 'status');
+    notification.setAttribute('aria-live', type === 'error' ? 'assertive' : 'polite');
+
     // Add to page
     document.body.appendChild(notification);
-    
+
     // Auto remove after 5 seconds
+    const hideNotification = () => {
+        if (!notification.classList.contains('notification-hide')) {
+            notification.classList.add('notification-hide');
+            notification.setAttribute('aria-hidden', 'true');
+            notification.addEventListener('animationend', () => {
+                notification.remove();
+            }, { once: true });
+        }
+    };
+
     setTimeout(() => {
         if (notification.parentNode) {
-            notification.style.animation = 'slideOutRight 0.3s ease';
-            setTimeout(() => notification.remove(), 300);
+            hideNotification();
         }
     }, 5000);
-    
+
     // Close button functionality
     const closeBtn = notification.querySelector('.notification-close');
     closeBtn.addEventListener('click', () => {
-        notification.style.animation = 'slideOutRight 0.3s ease';
-        setTimeout(() => notification.remove(), 300);
+        hideNotification();
     });
 }
-
-// Add CSS for notifications
-const notificationStyles = document.createElement('style');
-notificationStyles.textContent = `
-    @keyframes slideInRight {
-        from {
-            transform: translateX(100%);
-            opacity: 0;
-        }
-        to {
-            transform: translateX(0);
-            opacity: 1;
-        }
-    }
-    
-    @keyframes slideOutRight {
-        from {
-            transform: translateX(0);
-            opacity: 1;
-        }
-        to {
-            transform: translateX(100%);
-            opacity: 0;
-        }
-    }
-    
-    .notification-content {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 15px;
-    }
-    
-    .notification-close {
-        background: none;
-        border: none;
-        color: white;
-        font-size: 20px;
-        cursor: pointer;
-        padding: 0;
-        line-height: 1;
-    }
-    
-    .notification-close:hover {
-        opacity: 0.8;
-    }
-    
-    .nav-link.active {
-        color: #d4af37;
-    }
-    
-    .nav-link.active::after {
-        width: 100%;
-    }
-`;
-document.head.appendChild(notificationStyles);
 
 // Intersection Observer for animations
 const observerOptions = {

--- a/styles.css
+++ b/styles.css
@@ -165,6 +165,14 @@ h3 {
     width: 100%;
 }
 
+.nav-link.active {
+    color: #d4af37;
+}
+
+.nav-link.active::after {
+    width: 100%;
+}
+
 .hamburger {
     display: none;
     flex-direction: column;
@@ -669,7 +677,90 @@ h3 {
     color: #ccc;
 }
 
+/* Notification System */
+.notification {
+    position: fixed;
+    top: 90px;
+    right: 20px;
+    background: #2196f3;
+    color: #fff;
+    padding: 15px 20px;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    z-index: 10000;
+    max-width: 400px;
+    display: flex;
+    align-items: center;
+    animation: slideInRight 0.3s ease forwards;
+}
+
+.notification-success {
+    background: #4caf50;
+}
+
+.notification-error {
+    background: #f44336;
+}
+
+.notification-info {
+    background: #2196f3;
+}
+
+.notification-hide {
+    animation: slideOutRight 0.3s ease forwards;
+}
+
+.notification-content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 15px;
+    width: 100%;
+}
+
+.notification-message {
+    flex: 1;
+}
+
+.notification-close {
+    background: transparent;
+    border: none;
+    color: inherit;
+    font-size: 20px;
+    cursor: pointer;
+    padding: 0;
+    line-height: 1;
+    transition: opacity 0.2s ease;
+}
+
+.notification-close:hover,
+.notification-close:focus {
+    opacity: 0.8;
+}
+
 /* Animations */
+@keyframes slideInRight {
+    from {
+        transform: translateX(100%);
+        opacity: 0;
+    }
+    to {
+        transform: translateX(0);
+        opacity: 1;
+    }
+}
+
+@keyframes slideOutRight {
+    from {
+        transform: translateX(0);
+        opacity: 1;
+    }
+    to {
+        transform: translateX(100%);
+        opacity: 0;
+    }
+}
+
 @keyframes fadeInUp {
     from {
         opacity: 0;


### PR DESCRIPTION
## Summary
- add persistent notification styles and animations to the main stylesheet
- update the notification script to toggle CSS classes and accessibility attributes instead of inline styles
- ensure navigation active link styling lives in CSS rather than injected styles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d980ed65688322b1980cec32f2d14a