### PR TITLE
Improve initial load fade handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 </head>
-<body>
+<body class="is-loading">
     <!-- Navigation -->
     <nav class="navbar">
         <div class="nav-container">

--- a/script.js
+++ b/script.js
@@ -28,6 +28,29 @@ document.querySelectorAll('a[href^="#"]').forEach(anchor => {
     });
 });
 
+// Loading state handling
+const removeLoadingState = () => {
+    document.body.classList.remove('is-loading');
+};
+
+const handleInitialLoad = () => {
+    requestAnimationFrame(() => {
+        requestAnimationFrame(removeLoadingState);
+    });
+};
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', handleInitialLoad);
+} else {
+    handleInitialLoad();
+}
+
+window.addEventListener('pageshow', (event) => {
+    if (event.persisted) {
+        removeLoadingState();
+    }
+});
+
 // Navbar background change on scroll
 window.addEventListener('scroll', () => {
     const navbar = document.querySelector('.navbar');
@@ -273,16 +296,6 @@ window.addEventListener('scroll', () => {
         const rate = scrolled * -0.5;
         heroImage.style.transform = `translateY(${rate}px)`;
     }
-});
-
-// Loading animation
-window.addEventListener('load', () => {
-    document.body.style.opacity = '0';
-    document.body.style.transition = 'opacity 0.5s ease';
-    
-    setTimeout(() => {
-        document.body.style.opacity = '1';
-    }, 100);
 });
 
 // Add smooth transitions to all interactive elements

--- a/sizing-guide.html
+++ b/sizing-guide.html
@@ -205,7 +205,7 @@
         }
     </style>
 </head>
-<body>
+<body class="is-loading">
     <!-- Navigation -->
     <nav class="navbar">
         <div class="nav-container">

--- a/styles.css
+++ b/styles.css
@@ -14,6 +14,12 @@ body {
     line-height: 1.6;
     color: #333;
     overflow-x: hidden;
+    opacity: 1;
+    transition: opacity 0.5s ease;
+}
+
+body.is-loading {
+    opacity: 0;
 }
 
 .container {


### PR DESCRIPTION
## Summary
- add a body loading class in the markup and CSS to control initial opacity without inline scripting
- update the JavaScript loader to remove the class via requestAnimationFrame and handle bfcache restores
- remove the load-event opacity toggle and retain smooth transitions for interactive elements

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d980ef430c832298c7bc1c735a49fa